### PR TITLE
Add an option to push a notification immediately

### DIFF
--- a/alarmee/src/androidMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerAndroid.kt
+++ b/alarmee/src/androidMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerAndroid.kt
@@ -107,6 +107,29 @@ class AlarmeeSchedulerAndroid(
         }
     }
 
+    fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+        createNotificationChannels(context = context)
+        validateNotificationChannelId(channelId = channelId)
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .apply {
+                setSmallIcon(configuration.notificationIconResId)
+                setContentTitle(title)
+                setContentText(body)
+                setPriority(mapPriority(priority))
+                setAutoCancel(true)
+            }
+            .build()
+
+        context.getNotificationManager()?.let { notificationManager ->
+            if (notificationManager.areNotificationsEnabled()) {
+                notificationManager.notify(uuid.hashCode(), notification)
+            } else {
+                println("Notifications permission is not granted! Can't show the notification.")
+            }
+        }
+    }
+
     private fun createNotificationChannels(context: Context) {
         // Create a notification channel for Android O and above
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -131,6 +154,16 @@ class AlarmeeSchedulerAndroid(
             context.getNotificationManager()?.let { notificationManager ->
                 val channelExists = notificationManager.notificationChannels.any { it.id == alarmee.androidNotificationConfiguration.channelId }
                 require(channelExists) { "The Alarmee is set with a notification channel (ID: ${alarmee.androidNotificationConfiguration.channelId}) that doest not exist." }
+            }
+        }
+    }
+
+    private fun validateNotificationChannelId(channelId: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Make sure channel exists
+            context.getNotificationManager()?.let { notificationManager ->
+                val channelExists = notificationManager.notificationChannels.any { it.id == channelId }
+                require(channelExists) { "The notification channel (ID: $channelId) does not exist." }
             }
         }
     }

--- a/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeScheduler.kt
+++ b/alarmee/src/commonMain/kotlin/com/tweener/alarmee/AlarmeeScheduler.kt
@@ -76,6 +76,8 @@ abstract class AlarmeeScheduler {
 
     internal abstract fun cancelAlarm(uuid: String)
 
+    abstract fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority)
+
     private fun validateAlarmee(alarmee: Alarmee) {
         if (alarmee.repeatInterval is RepeatInterval.Custom) {
             require(alarmee.repeatInterval.duration.isPositive()) { "Custom repeat interval duration must be greater than zero." }

--- a/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
+++ b/alarmee/src/iosMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerIos.kt
@@ -113,6 +113,31 @@ class AlarmeeSchedulerIos(
         notificationCenter.removePendingNotificationRequestsWithIdentifiers(identifiers = listOf(uuid, getFirstRepeatingNotificationUuid(uuid = uuid)))
     }
 
+    fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+        val content = UNMutableNotificationContent().apply {
+            setTitle(title)
+            setBody(body)
+        }
+
+        val trigger = UNTimeIntervalNotificationTrigger.triggerWithTimeInterval(1.0, repeats = false)
+
+        val request = UNNotificationRequest.requestWithIdentifier(identifier = uuid, content = content, trigger = trigger)
+
+        val notificationCenter = UNUserNotificationCenter.currentNotificationCenter()
+        notificationCenter.requestAuthorizationWithOptions(options = UNAuthorizationOptionAlert or UNAuthorizationOptionSound or UNAuthorizationOptionBadge) { granted, authorizationError ->
+            if (granted) {
+                // Schedule the notification
+                notificationCenter.addNotificationRequest(request) { requestError ->
+                    if (requestError != null) {
+                        println("Scheduling notification on iOS failed with error: $requestError")
+                    }
+                }
+            } else if (authorizationError != null) {
+                println("Error requesting notification permission: $authorizationError")
+            }
+        }
+    }
+
     private fun configureNotification(uuid: String, alarmee: Alarmee, notificationTrigger: UNNotificationTrigger, onSuccess: () -> Unit) {
         val content = UNMutableNotificationContent().apply {
             setTitle(alarmee.notificationTitle)

--- a/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
+++ b/alarmee/src/jsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJs.kt
@@ -32,4 +32,22 @@ class AlarmeeSchedulerJs(
     override fun cancelAlarm(uuid: String) {
         TODO("Not yet implemented")
     }
+
+    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+        if (!("Notification" in js("window"))) {
+            println("This browser does not support notifications.")
+            return
+        }
+
+        val permission = js("Notification.permission").toString()
+        if (permission == "granted") {
+            val notification = js("new Notification(title, { body: body })")
+        } else if (permission != "denied") {
+            js("Notification.requestPermission()").then { result ->
+                if (result == "granted") {
+                    val notification = js("new Notification(title, { body: body })")
+                }
+            }
+        }
+    }
 }

--- a/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
+++ b/alarmee/src/jvmMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerJvm.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.tweener.alarmee.configuration.AlarmeePlatformConfiguration
 import com.tweener.alarmee.configuration.AlarmeeJvmPlatformConfiguration
+import java.awt.*
+import java.awt.TrayIcon.MessageType
 
 /**
  * @author Vivien Mahe
@@ -31,5 +33,19 @@ class AlarmeeSchedulerJvm(
 
     override fun cancelAlarm(uuid: String) {
         TODO("Not yet implemented")
+    }
+
+    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+        if (SystemTray.isSupported()) {
+            val tray = SystemTray.getSystemTray()
+            val image = Toolkit.getDefaultToolkit().createImage("icon.png")
+            val trayIcon = TrayIcon(image, "Tray Demo")
+            trayIcon.isImageAutoSize = true
+            trayIcon.toolTip = "System tray icon demo"
+            trayIcon.displayMessage(title, body, MessageType.INFO)
+            tray.add(trayIcon)
+        } else {
+            println("System tray not supported!")
+        }
     }
 }

--- a/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
+++ b/alarmee/src/wasmJsMain/kotlin/com/tweener/alarmee/AlarmeeSchedulerWasmJs.kt
@@ -32,4 +32,22 @@ class AlarmeeSchedulerWasmJs(
     override fun cancelAlarm(uuid: String) {
         TODO("Not yet implemented")
     }
+
+    override fun pushNotificationNow(uuid: String, title: String, body: String, channelId: String, priority: AndroidNotificationPriority) {
+        if (!("Notification" in js("window"))) {
+            println("This browser does not support notifications.")
+            return
+        }
+
+        val permission = js("Notification.permission").toString()
+        if (permission == "granted") {
+            val notification = js("new Notification(title, { body: body })")
+        } else if (permission != "denied") {
+            js("Notification.requestPermission()").then { result ->
+                if (result == "granted") {
+                    val notification = js("new Notification(title, { body: body })")
+                }
+            }
+        }
+    }
 }

--- a/sample/composeApp/src/commonMain/kotlin/com/tweener/alarmee/sample/App.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/tweener/alarmee/sample/App.kt
@@ -93,6 +93,16 @@ fun App() {
                         )
                     )
                 }) { Text("Set a custom repeating Alarmee") }
+
+                Button(onClick = {
+                    alarmeeScheduler.pushNotificationNow(
+                        uuid = "immediateNotificationId",
+                        title = "🚀 Immediate Notification",
+                        body = "This is an immediate notification pushed without any schedule.",
+                        channelId = "immediateChannelId",
+                        priority = AndroidNotificationPriority.HIGH
+                    )
+                }) { Text("Push Notification Now") }
             }
         }
     }


### PR DESCRIPTION
Add functionality to push a notification immediately without any schedule.

* **Android Implementation**
  - Add `pushNotificationNow` method to `AlarmeeSchedulerAndroid` class.
  - Implement the method to create and display a notification using `NotificationCompat.Builder`.
  - Add `validateNotificationChannelId` method to ensure the notification channel exists.

* **Common Implementation**
  - Add abstract `pushNotificationNow` method to `AlarmeeScheduler` class.

* **Compose App**
  - Add a new button to the `App` composable to push a notification immediately.
  - Implement the button's `onClick` handler to call the `pushNotificationNow` method.

* **iOS Implementation**
  - Add `pushNotificationNow` method to `AlarmeeSchedulerIos` class.
  - Implement the method to create and display a notification using `UNUserNotificationCenter`.

* **JavaScript Implementation**
  - Add `pushNotificationNow` method to `AlarmeeSchedulerJs` class.
  - Implement the method to create and display a notification using JavaScript's `Notification` API.

* **JVM Implementation**
  - Add `pushNotificationNow` method to `AlarmeeSchedulerJvm` class.
  - Implement the method to create and display a notification using Java's `SystemTray` and `TrayIcon`.

* **WasmJs Implementation**
  - Add `pushNotificationNow` method to `AlarmeeSchedulerWasmJs` class.
  - Implement the method to create and display a notification using WebAssembly's `Notification` API.

